### PR TITLE
Fixing preg_replace and CURL options

### DIFF
--- a/includes/xmlrpc.inc
+++ b/includes/xmlrpc.inc
@@ -820,7 +820,7 @@
 		var $key='';
 		var $keypass='';
 		var $verifypeer=true;
-		var $verifyhost=1;
+		var $verifyhost=2;
 		var $no_multicall=false;
 		var $proxy='';
 		var $proxyport=0;

--- a/pmpro-infusionsoft.php
+++ b/pmpro-infusionsoft.php
@@ -66,10 +66,10 @@ function pmprois_updateInfusionsoftContact($email, $tags = NULL)
 	$app = new iSDK($options['id'], "infusion", $options['api_key']);
 	
 	$returnFields = array('Id');
-	$dups = $app->findByEmail($email, $returnFields);			
-			
+    $dups = $app->findByEmail($email, $returnFields);
+		
 	//no? add them
-	if(!is_array($dups))
+	if(empty($dups))
 	{		
 		$contact_id = $app->addCon(array("Email"=>$email));
 	}
@@ -311,7 +311,7 @@ function pmprois_options_validate($input)
 	{
 		foreach($pmprois_levels as $level)
 		{
-			$newinput['level_' . $level->id . '_tags'] = trim(preg_replace("[^a-zA-Z0-9\-\s", "", $input['level_' . $level->id . '_tags']));				
+			$newinput['level_' . $level->id . '_tags'] = trim(preg_replace("[^a-zA-Z0-9\-\s]", "", $input['level_' . $level->id . '_tags']));				
 		}
 	}
 	


### PR DESCRIPTION
These edits fix a missing ']' in a preg_replace function and also adjust the $verifyhost value in CURL to 2, as 1 is being deprecated soon.
